### PR TITLE
Discord link

### DIFF
--- a/cogs/link.py
+++ b/cogs/link.py
@@ -1,0 +1,45 @@
+import interactions, asyncio
+from embed.osu import create_osu_embed
+class Link(interactions.Extension): # must have interactions.Extension or this wont work
+    def __init__(self, client):
+        self.client: interactions.Client = client
+        self.osu = client.auth
+        self.database = client.database
+
+    @interactions.extension_command(
+            name="link", 
+            description="links your discord account to an osu! account",
+            options=[interactions.Option(
+                name="username",
+                description="the username of the osu! account you want to link to",
+                type=interactions.OptionType.STRING,
+                required=True,
+            )
+        ]
+    )
+    async def link(self, ctx: interactions.CommandContext, username: str):
+        await ctx.defer()
+        discord_id = ctx.author.id._snowflake
+        alter_account = False
+        if await self.database.get_link(discord_id):
+            # Checks if we are modifying an account or adding a new one to the db
+            alter_account = True
+        
+        # get osu account details
+        osu_account_data = await self.osu.get_user(username)
+        if not(osu_account_data):
+            await ctx.send(f"User {username} was not found on osu! - did you write it correctly?")
+            return
+        
+        if alter_account is False:
+            await self.database.add_link(discord_id, osu_account_data['id'])
+            await ctx.send(f"<@{discord_id}> has been linked to {username}!")
+            return
+        else:
+            await self.database.update_link(discord_id, osu_account_data['id'])
+            await ctx.send(f"<@{discord_id}> has been linked to {username}!")
+            return
+
+
+def setup(client):
+    Link(client)

--- a/cogs/link.py
+++ b/cogs/link.py
@@ -26,7 +26,7 @@ class Link(interactions.Extension): # must have interactions.Extension or this w
             alter_account = True
         
         # get osu account details
-        osu_account_data = await self.osu.get_user(username)
+        osu_account_data = await self.osu.get_user_data(username)
         if not(osu_account_data):
             await ctx.send(f"User {username} was not found on osu! - did you write it correctly?")
             return

--- a/cogs/osu.py
+++ b/cogs/osu.py
@@ -1,23 +1,30 @@
-import interactions, asyncio
+import interactions
+import asyncio
 from embed.osu import create_osu_embed
-class Osu(interactions.Extension): # must have interactions.Extension or this wont work
+
+
+class Osu(interactions.Extension):  # must have interactions.Extension or this wont work
     def __init__(self, client):
         self.client: interactions.Client = client
         self.osu = client.auth
+        self.database = client.database
 
     @interactions.extension_command(
-            name="osu", 
-            description="get a users osu profile details",
-            options=[interactions.Option(
-                name="username",
-                description="the username of the user",
-                type=interactions.OptionType.STRING,
-                required=True,
-            )
+        name="osu",
+        description="get a users osu profile details",
+        options=[interactions.Option(
+            name="username",
+            description="the username of the user",
+            type=interactions.OptionType.STRING,
+            required=False,
+        )
         ]
     )
-    async def osu(self, ctx: interactions.CommandContext, username: str):
+    async def osu(self, ctx: interactions.CommandContext, *args, **kwargs):
         await ctx.defer()
+        username = await self.handle_linked_account(ctx, kwargs)
+        if not username:
+            return
         recent_plays = await self.osu.get_recent_plays("3637436")
         score_data = await self.osu.get_score_data("848345", "10609949")
         score_data_mods = await self.osu.get_beatmap_mods("848345", "64")
@@ -25,6 +32,18 @@ class Osu(interactions.Extension): # must have interactions.Extension or this wo
         user_data = await self.osu.get_user_data(username)
         embed = await create_osu_embed(user_data)
         await ctx.send(embeds=embed)
+
+    async def handle_linked_account(self, ctx, kwargs):
+        if len(kwargs) > 0:
+            return kwargs['username']
+        else:
+            username_array = await self.database.get_linked_user_osu_id(ctx.author.id._snowflake)
+            if not username_array:
+                await ctx.send("You are not linked to an osu! account - use `/link` to link your account\n" \
+                                "Alternatively you can do `/osu username:username` to get a specific persons profile")
+                return False
+            return username_array[0]
+
 
 def setup(client):
     Osu(client)

--- a/database/_init_db.py
+++ b/database/_init_db.py
@@ -236,6 +236,11 @@ class Database:
             "SELECT * FROM snipes WHERE second_user_id=?",
             (main_user_id,)).fetchall()
 
+    async def get_linked_user_osu_id(self, discord_id):
+        return self.cursor.execute(
+            "SELECT osu_id FROM link WHERE discord_id=?",
+            (discord_id,)).fetchone()
+
     ## ADDS
     async def add_channel(self, channel_id, user_id, user_data):
         user_data = await self.osu.get_user_data(str(user_id))

--- a/database/_init_db.py
+++ b/database/_init_db.py
@@ -55,7 +55,7 @@ class Database:
                 ping boolean,
                 leaderboard varchar(16)
             )
-        ''')
+        ''') # Ping value for this is redundant but will take time to alter so keeping it for now
 
         self.cursor.execute('''
             CREATE TABLE IF NOT EXISTS beatmaps(
@@ -93,6 +93,14 @@ class Database:
                 second_pp varchar(16)
             )
         ''')  # for storing if someone has been sniped on a specific beatmap
+
+        self.cursor.execute('''
+            CREATE TABLE IF NOT EXISTS link(
+                discord_id varchar(32) not null,
+                osu_id varchar(32) not null,
+                ping boolean,
+            )
+        ''')
 
     ## CUSTOM (WIP)
     async def custom_get(self, query):

--- a/database/_init_db.py
+++ b/database/_init_db.py
@@ -107,6 +107,11 @@ class Database:
         return self.cursor.execute(query).fetchall()
 
     ## GETS
+    async def get_link(self, discord_id):
+        return self.cursor.execute(
+            "SELECT * FROM link WHERE discord_id=?",
+            (discord_id,)).fetchone()
+
     async def get_channel(self, discord_id):
         return self.cursor.execute(
             "SELECT * FROM users WHERE discord_channel=?",
@@ -273,7 +278,21 @@ class Database:
         )
         self.db.commit()    
 
+    async def add_link(self, discord_id, user_id):
+        self.cursor.execute(
+            "INSERT INTO link VALUES(?,?,?)",
+            (discord_id, user_id, False)
+        )
+        self.db.commit()
+
     ## UPDATES
+    async def update_link(self, discord_id, user_id):
+        self.cursor.execute(
+            "UPDATE link SET osu_id=? WHERE discord_id=?",
+            (user_id, discord_id)
+        )
+        self.db.commit()
+
     async def update_score(self, user_id, beatmap_id, score, accuracy, max_combo, passed, pp, rank, count_300, count_100, count_50, count_miss, date, mods, conv_stars, conv_bpm):
         self.cursor.execute(
             "UPDATE scores SET score=?, accuracy=?, max_combo=?, passed=?, pp=?, rank=?, count_300=?, count_100=?, count_50=?, count_miss=?, date=?, mods=?, converted_stars=?, converted_bpm=? WHERE user_id=? AND beatmap_id=?",

--- a/database/_init_db.py
+++ b/database/_init_db.py
@@ -98,7 +98,7 @@ class Database:
             CREATE TABLE IF NOT EXISTS link(
                 discord_id varchar(32) not null,
                 osu_id varchar(32) not null,
-                ping boolean,
+                ping boolean
             )
         ''')
 


### PR DESCRIPTION
**Discord to osu! account linking**

- New command `/link`
- New database table `link`
- `Username` no longer required for `/osu`, `/stats` and `/snipes`
- If a user does not specify `Username` for a command, it tries to take their linked osu! id instead